### PR TITLE
Deduplicate SHOW_ELAPSED_TIME properties to address v8r error

### DIFF
--- a/megalinter/descriptors/schemas/megalinter-configuration.jsonschema.json
+++ b/megalinter/descriptors/schemas/megalinter-configuration.jsonschema.json
@@ -13814,7 +13814,7 @@
       "type": "string"
     },
     "VALIDATE_ALL_CODEBASE": {
-      "$id": "#/properties/SHOW_ELAPSED_TIME",
+      "$id": "#/properties/VALIDATE_ALL_CODEBASE",
       "default": true,
       "description": "Will parse the entire repository and find all files to validate across all types. When set to false, only new or edited files will be parsed for validation.",
       "title": "Validate all code base",


### PR DESCRIPTION
## Proposed Changes

If you run the [v8r](https://github.com/chris48s/v8r) tool on a `.mega-linter.yml` file that contains a `SHOW_ELAPSED_TIME` key, you will get the following error:

```bash
ℹ Processing .mega-linter.yml
ℹ Found schema in https://www.schemastore.org/api/json/catalog.json ...
ℹ Validating .mega-linter.yml against schema from https://raw.githubusercontent.com/megalinter/megalinter/main/megalinter/descriptors/schemas/megalinter-configuration.jsonschema.json ...
✖ reference "http://github.com/oxsecurity/megalinter-configuration.json#/properties/SHOW_ELAPSED_TIME" resolves to more than one schema
```

This is because the `megalinter/descriptors/schemas/megalinter-configuration.jsonschema.json` file has two `SHOW_ELAPSED_TIME` properties due to a typo. This PR fixes this typo.

## Readiness Checklist

### Author/Contributor
- [ ] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [x] Label as `breaking` if this is a large fundamental change
- [x] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
